### PR TITLE
A minor addition to your delegate

### DIFF
--- a/CrashPhone/CAAppDelegate.m
+++ b/CrashPhone/CAAppDelegate.m
@@ -61,6 +61,12 @@
 - (void)notifierDidDismissAlert {
 	NSLog(@"%s", __PRETTY_FUNCTION__);
 }
+- (void)notifierWillPostNotices {
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+- (void)notifierDidPostNotices {
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
 - (NSString *)titleForNoticeAlert {
 	NSLog(@"%s", __PRETTY_FUNCTION__);
 	return nil;

--- a/CrashPhone/CrashPhone.xcodeproj/xcshareddata/xcschemes/CrashPhone.xcscheme
+++ b/CrashPhone/CrashPhone.xcodeproj/xcshareddata/xcschemes/CrashPhone.xcscheme
@@ -30,8 +30,8 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       displayScaleIsEnabled = "NO"
       displayScale = "1.00"
       launchStyle = "0"

--- a/hoptoadnotifier/HTNotifier.m
+++ b/hoptoadnotifier/HTNotifier.m
@@ -117,6 +117,12 @@ NSString * const HTNotifierAlwaysSendKey = @"AlwaysSendCrashReports";
 }
 - (void)postNoticesWithPaths:(NSArray *)paths {
 
+    if (nil != paths && [paths count] > 0) {
+        if ([self.delegate respondsToSelector:@selector(notifierWillPostNotices)]) {
+            [self.delegate notifierWillPostNotices];
+        }
+    }
+    
 #if HT_IOS_SDK_4
 	
 	if (HTIsMultitaskingSupported) {
@@ -154,6 +160,12 @@ NSString * const HTNotifierAlwaysSendKey = @"AlwaysSendCrashReports";
 	}
 	
 #endif
+    
+    if (nil != paths && [paths count] > 0) {
+        if ([self.delegate respondsToSelector:@selector(notifierDidPostNotices)]) {
+            [self.delegate notifierDidPostNotices];
+        }
+    }
 	
 }
 - (void)postNoticeWithPath:(NSString *)path {

--- a/hoptoadnotifier/HTNotifierDelegate.h
+++ b/hoptoadnotifier/HTNotifierDelegate.h
@@ -42,6 +42,14 @@
 - (NSString *)titleForNoticeAlert;
 - (NSString *)bodyForNoticeAlert;
 
+
+/*
+ These methods allow your application to perform actions
+ before and after notices are posted to the server.
+ */
+- (void)notifierWillPostNotices;
+- (void)notifierDidPostNotices;
+
 /*
  
  This lets the app delegate know that an event causing a


### PR DESCRIPTION
I want to post some additional log information after a crash is reported; I'm sending this to my own server. As I'm using your great alert view to allow folks to decide if information is posted or not (once or always), I decided to add a delegate method that is called after notices have been posted. 

In order to be symmetrical I added will post and did post methods and added these to the iOS sample project. Would have added them to the Mac project, but that didn't have any of the other delegate methods so I didn't bother :)
