### PR TITLE
Fixed some compiler warnings

### DIFF
--- a/Hoptoad Sample.xcodeproj/project.pbxproj
+++ b/Hoptoad Sample.xcodeproj/project.pbxproj
@@ -107,7 +107,7 @@
 		3BA58928137C871300D9C544 /* ru */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/HTNotifier.strings; sourceTree = "<group>"; };
 		3BA58935137C87C000D9C544 /* INSTALLATION.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = INSTALLATION.html; sourceTree = "<group>"; wrapsLines = 1; };
 		3BA58936137C87C000D9C544 /* README.markdown */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.markdown; sourceTree = "<group>"; wrapsLines = 1; };
-		3BFC84DB139C5F54000D2BB2 /* CHANGELOG */ = {isa = PBXFileReference; path = CHANGELOG; sourceTree = "<group>"; };
+		3BFC84DB139C5F54000D2BB2 /* CHANGELOG */ = {isa = PBXFileReference; lastKnownFileType = text; path = CHANGELOG; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -329,6 +329,7 @@
 		3B2E0B1A137A11B1009B558C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastUpgradeCheck = 0420;
 				ORGANIZATIONNAME = "GUI Cocoa, LLC.";
 			};
 			buildConfigurationList = 3B2E0B1D137A11B1009B558C /* Build configuration list for PBXProject "Hoptoad Sample" */;
@@ -516,6 +517,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
@@ -528,6 +530,7 @@
 			buildSettings = {
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;

--- a/hoptoadnotifier/HTFunctions.h
+++ b/hoptoadnotifier/HTFunctions.h
@@ -30,34 +30,34 @@
 #endif
 
 // start handlers
-void HTStartHandlers();
-void HTStartExceptionHandler();
-void HTStartSignalHandler();
+void HTStartHandlers(void);
+void HTStartExceptionHandler(void);
+void HTStartSignalHandler(void);
 
 // stop handlers
-void HTStopHandlers();
-void HTStopExceptionHandler();
-void HTStopSignalHandler();
+void HTStopHandlers(void);
+void HTStopExceptionHandler(void);
+void HTStopSignalHandler(void);
 
 // get values from Info.plist
 id HTInfoPlistValueForKey(NSString *);
-NSString *HTExecutableName();
-NSString *HTApplicationVersion();
-NSString *HTBundleVersion();
-NSString *HTApplicationName();
+NSString *HTExecutableName(void);
+NSString *HTApplicationVersion(void);
+NSString *HTBundleVersion(void);
+NSString *HTApplicationName(void);
 
 // get platform values
-NSString *HTOperatingSystemVersion();
-NSString *HTMachine();
-NSString *HTPlatform();
+NSString *HTOperatingSystemVersion(void);
+NSString *HTMachine(void);
+NSString *HTPlatform(void);
 
 // deal with notice information
-void HTInitNoticeInfo();
-void HTReleaseNoticeInfo();
+void HTInitNoticeInfo(void);
+void HTReleaseNoticeInfo(void);
 
 // deal with notice information on disk
-NSString * HTNoticesDirectory();
-NSArray * HTNotices();
+NSString * HTNoticesDirectory(void);
+NSArray * HTNotices(void);
 
 // callstack utilities
 NSArray *HTCallStackSymbolsFromReturnAddresses(NSArray *);
@@ -88,7 +88,7 @@ NSString * HTStringByReplacingHoptoadVariablesInString(NSString *);
  inspected (if it exists)
  
  */
-NSString * HTCurrentViewController();
+NSString * HTCurrentViewController(void);
 
 /*
  

--- a/hoptoadnotifier/HTFunctions.m
+++ b/hoptoadnotifier/HTFunctions.m
@@ -154,14 +154,14 @@ int ht_open_file(int type) {
 }
 
 #pragma mark - modify handler state
-void HTStartHandlers() {
+void HTStartHandlers(void) {
     HTStartExceptionHandler();
     HTStartSignalHandler();
 }
-void HTStartExceptionHandler() {
+void HTStartExceptionHandler(void) {
     NSSetUncaughtExceptionHandler(&ht_handle_exception);
 }
-void HTStartSignalHandler() {
+void HTStartSignalHandler(void) {
 	for (NSUInteger i = 0; i < ht_signals_count; i++) {
 		int signal = ht_signals[i];
 		struct sigaction action;
@@ -173,14 +173,14 @@ void HTStartSignalHandler() {
 		}
 	}
 }
-void HTStopHandlers() {
+void HTStopHandlers(void) {
     HTStopExceptionHandler();
     HTStopSignalHandler();
 }
-void HTStopExceptionHandler() {
+void HTStopExceptionHandler(void) {
     NSSetUncaughtExceptionHandler(NULL);
 }
-void HTStopSignalHandler() {
+void HTStopSignalHandler(void) {
 	for (NSUInteger i = 0; i < ht_signals_count; i++) {
 		int signal = ht_signals[i];
 		struct sigaction action;
@@ -194,10 +194,10 @@ void HTStopSignalHandler() {
 id HTInfoPlistValueForKey(NSString *key) {
 	return [[[NSBundle mainBundle] infoDictionary] objectForKey:key];
 }
-NSString *HTExecutableName() {
+NSString *HTExecutableName(void) {
 	return HTInfoPlistValueForKey(@"CFBundleExecutable");
 }
-NSString *HTApplicationVersion() {
+NSString *HTApplicationVersion(void) {
 	NSString *bundleVersion = HTBundleVersion();
 	NSString *versionString = HTInfoPlistValueForKey(@"CFBundleShortVersionString");
 	if (bundleVersion != nil && versionString != nil) {
@@ -207,10 +207,10 @@ NSString *HTApplicationVersion() {
 	else if (versionString != nil) { return versionString; }
 	else { return nil; }
 }
-NSString *HTBundleVersion() {
+NSString *HTBundleVersion(void) {
     return HTInfoPlistValueForKey(@"CFBundleVersion");
 }
-NSString *HTApplicationName() {
+NSString *HTApplicationName(void) {
 	NSString *displayName = HTInfoPlistValueForKey(@"CFBundleDisplayName");
 	NSString *bundleName = HTInfoPlistValueForKey(@"CFBundleName");
 	NSString *identifier = HTInfoPlistValueForKey(@"CFBundleIdentifier");
@@ -221,14 +221,14 @@ NSString *HTApplicationName() {
 }
 
 #pragma mark - platform accessors
-NSString *HTOperatingSystemVersion() {
+NSString *HTOperatingSystemVersion(void) {
 #if TARGET_IPHONE_SIMULATOR
 	return [[UIDevice currentDevice] systemVersion];
 #else
 	return [[NSProcessInfo processInfo] operatingSystemVersionString];
 #endif
 }
-NSString *HTMachine() {
+NSString *HTMachine(void) {
 #if TARGET_IPHONE_SIMULATOR
 	return @"iPhone Simulator";
 #else
@@ -246,7 +246,7 @@ NSString *HTMachine() {
     
 #endif
 }
-NSString *HTPlatform() {
+NSString *HTPlatform(void) {
 #if TARGET_IPHONE_SIMULATOR
 	return @"iPhone Simulator";
 #else
@@ -279,7 +279,7 @@ NSString *HTPlatform() {
 }
 
 #pragma mark - init notice info
-void HTInitNoticeInfo() {
+void HTInitNoticeInfo(void) {
     
     NSString *value;
     const char *value_str;
@@ -351,7 +351,7 @@ void HTInitNoticeInfo() {
     }
     
 }
-void HTReleaseNoticeInfo() {
+void HTReleaseNoticeInfo(void) {
     free((void *)ht_notice_info.notice_path);
     ht_notice_info.notice_path = NULL;
     free((void *)ht_notice_info.os_version);
@@ -375,7 +375,7 @@ void HTReleaseNoticeInfo() {
 }
 
 #pragma mark - notice information on disk
-NSString * HTNoticesDirectory() {
+NSString * HTNoticesDirectory(void) {
 #if TARGET_OS_IPHONE
 	NSArray *folders = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
 	NSString *path = [folders objectAtIndex:0];
@@ -389,7 +389,7 @@ NSString * HTNoticesDirectory() {
 	return [path stringByAppendingPathComponent:HTNotifierDirectoryName];
 #endif
 }
-NSArray * HTNotices() {
+NSArray * HTNotices(void) {
 	NSString *directory = HTNoticesDirectory();
 	NSArray *directoryContents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:directory error:nil];
 	NSMutableArray *crashes = [NSMutableArray arrayWithCapacity:[directoryContents count]];
@@ -463,7 +463,7 @@ NSString * HTStringByReplacingHoptoadVariablesInString(NSString *string) {
 
 #pragma mark - get view controller
 #if TARGET_OS_IPHONE
-NSString * HTCurrentViewController() {
+NSString * HTCurrentViewController(void) {
 	// view controller to inspect
 	UIViewController *rootController = nil;
 	

--- a/hoptoadnotifier/HTNotifier.m
+++ b/hoptoadnotifier/HTNotifier.m
@@ -425,7 +425,7 @@ NSString * const HTNotifierAlwaysSendKey = @"AlwaysSendCrashReports";
 - (NSUInteger)retainCount {
 	return NSUIntegerMax;
 }
-- (void)release {
+- (oneway void)release {
 	// do nothing
 }
 - (id)autorelease {


### PR DESCRIPTION
Fixed compiler warnings when using Apple LLVM 3.0 in XCode 4.2 (beta) and the advised compiler settings.

Added "oneway void" to the release method in HTNotifier.m
Added void as argument for plain C methods, this is needed according to the C99 spec and the compiler was complaining about this.
Added GCC_WARN_ABOUT_MISSING_PROTOTYPES as XCode suggests this from version 4.2 beta
