### PR TITLE
Changed the ABNotifierHostName to the new airbrake.io domain

### DIFF
--- a/Airbrake/notifier/ABNotifier.m
+++ b/Airbrake/notifier/ABNotifier.m
@@ -37,7 +37,7 @@ static NSString * __APIKey = nil;
 static BOOL __useSSL = NO;
 
 // constant strings
-static NSString * const ABNotifierHostName                  = @"airbrakeapp.com";
+static NSString * const ABNotifierHostName                  = @"airbrake.io";
 static NSString * const ABNotifierAlwaysSendKey             = @"AlwaysSendCrashReports";
 NSString * const ABNotifierWillDisplayAlertNotification     = @"ABNotifierWillDisplayAlert";
 NSString * const ABNotifierDidDismissAlertNotification      = @"ABNotifierDidDismissAlert";


### PR DESCRIPTION
Small change, but I think we should use the newest domain to submit all notices to AirBrake. Don't know how long the old one will be around, but it's good to be on the latest/newest domain to be save! :)
