### PR TITLE
Fix variable shadowing errors

### DIFF
--- a/Airbrake/notifier/ABNotifierFunctions.m
+++ b/Airbrake/notifier/ABNotifierFunctions.m
@@ -240,7 +240,7 @@ NSArray *ABNotifierParseCallStack(NSArray *callStack) {
         NSRegularExpression *expression = [NSRegularExpression regularExpressionWithPattern:pattern options:(NSRegularExpressionCaseInsensitive | NSRegularExpressionDotMatchesLineSeparators) error:nil];
         NSArray *components = [expression matchesInString:line options:NSMatchingReportCompletion range:NSMakeRange(0, [line length])];
         NSMutableArray *frame = [NSMutableArray arrayWithCapacity:[components count]];
-        [components enumerateObjectsUsingBlock:^(id result, NSUInteger idx, BOOL *stop) {
+        [components enumerateObjectsUsingBlock:^(id result, NSUInteger index, BOOL *s) {
             for (NSUInteger i = 0; i < [result numberOfRanges]; i++) {
                 [frame addObject:[line substringWithRange:[result rangeAtIndex:i]]];
             }


### PR DESCRIPTION
Without this change, it will not compile on newer versions of LLVM.
