### PR TITLE
add custom signal and exception handling

### DIFF
--- a/Airbrake/notifier/ABNotifierDelegate.h
+++ b/Airbrake/notifier/ABNotifierDelegate.h
@@ -71,6 +71,20 @@
  */
 - (void)notifierDidLogException:(NSException *)exception;
 
+/*
+
+ Informs the delegate that an exception was encountered
+
+ */
+- (void)notifierDidRecieveException:(NSException *)exception;
+
+/*
+
+ Informs the delegate that a signal was raised
+
+ */
+- (void)notifierDidRecieveSignal:(int)signal;
+
 #if TARGET_OS_IPHONE
 /*
  

--- a/Airbrake/notifier/ABNotifierFunctions.m
+++ b/Airbrake/notifier/ABNotifierFunctions.m
@@ -75,7 +75,12 @@ void ht_handle_signal(int signal, siginfo_t *info, void *context) {
         close(fd);
         
     }
-	
+
+    id<ABNotifierDelegate> delegte = [ABNotifier delegate];
+    if ([delegte respondsToSelector:@selector(notifierDidRecieveSignal:)]) {
+		[delegte notifierDidRecieveSignal:signal];
+	}
+
 	// re raise
 	raise(signal);
     
@@ -83,6 +88,10 @@ void ht_handle_signal(int signal, siginfo_t *info, void *context) {
 void ht_handle_exception(NSException *exception) {
     ABNotifierStopSignalHandler();
     ABNotifierStopExceptionHandler();
+    id<ABNotifierDelegate> delegte = [ABNotifier delegate];
+    if ([delegte respondsToSelector:@selector(notifierDidRecieveSignal:)]) {
+		[delegte notifierDidRecieveException:exception];
+	}
     [ABNotifier logException:exception];
 }
 


### PR DESCRIPTION
There may be cases where an application needs to do it's own cleanup after
encountering an unexpected signal or exception. ABNotifierDelegate now declares
two methods that are called during signal or exception handling that allow
the running application to do that cleanup.
