### PR TITLE
Changed location of libxml2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Airbrake supports a version floor for reported notices. A setting called "Latest
 # Installation
 1. Drag the Airbrake folder to your project and make sure "Copy Items" and "Create Groups" are selected
 2. Add `SystemConfiguration.framework` and `libxml2.dylib` to your project
-3. Add the path `/usr/include/libxml2` to Header Search Paths in your project's build settings under "All Configurations"
+3. Add the path `$SDK_DIR/usr/include/libxml2` to Header Search Paths in your project's build settings under "All Configurations"
 
 ## Upgrading
 Please remove all of the resources used by the notifier from your project before upgrading. This is the best way to make sure all of the appropriate files are present and no extra files exist.


### PR DESCRIPTION
Pointing to the sdk dir seems safer.
