### PR TITLE
Made hostName available as a parameter for startNotifier

### DIFF
--- a/Airbrake/notifier/ABNotifier.h
+++ b/Airbrake/notifier/ABNotifier.h
@@ -111,6 +111,27 @@ extern NSString * const ABNotifierDidPostNoticesNotification;
            installSignalHandler:(BOOL)signal
               displayUserPrompt:(BOOL)display;
 
++ (void)startNotifierWithAPIKey:(NSString *)key
+                       hostName:(NSString *)hostName
+                environmentName:(NSString *)name
+                         useSSL:(BOOL)useSSL
+                       delegate:(id<ABNotifierDelegate>)delegate;
++ (void)startNotifierWithAPIKey:(NSString *)key
+                       hostName:(NSString *)hostName
+                environmentName:(NSString *)name
+                         useSSL:(BOOL)useSSL
+                       delegate:(id<ABNotifierDelegate>)delegate
+        installExceptionHandler:(BOOL)exception
+           installSignalHandler:(BOOL)signal;
++ (void)startNotifierWithAPIKey:(NSString *)key
+                       hostName:(NSString *)hostName
+                environmentName:(NSString *)name
+                         useSSL:(BOOL)useSSL
+                       delegate:(id<ABNotifierDelegate>)delegate
+        installExceptionHandler:(BOOL)exception
+           installSignalHandler:(BOOL)signal
+              displayUserPrompt:(BOOL)display;
+
 /*
  
  Methods to expose some variables used by the notifier.


### PR DESCRIPTION
I just added NSString *hostName and added a static variable for the hostname as with the options for useSSL etc. The notifier falls back to the host defined in ABNotifierHostName if not passed in.