### PR TITLE
Specify OS X platform support in Podspec

### DIFF
--- a/Airbrake-iOS.podspec
+++ b/Airbrake-iOS.podspec
@@ -15,7 +15,8 @@ Pod::Spec.new do |s|
   
   s.author       = "Jocelyn Harrington"
   
-  s.platform     = :ios, "6.0"
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.7'
 
   s.source       = { :git => "https://github.com/airbrake/airbrake-ios.git", :tag => "4.1.2" }
 


### PR DESCRIPTION
This adds OS X support to the Podspec. Just FYI, running lint on the Podspec found a couple of other issues:

``` sh
$ pod spec lint Airbrake-iOS.podspec

 -> Airbrake-iOS (4.1.2)
    - WARN  | The URL (http://airbrake.io/pages/ios-notifier) is not reachable.
    - ERROR | [xcodebuild]  Airbrake-iOS/Airbrake/notifier/ABCrashReport.h:10:9: fatal error: 'CrashReporter/CrashReporter.h' file not found

Analyzed 1 podspec.

[!] The spec did not pass validation.
```
