### PR TITLE
Fix duplicate symbol error for ab_signal_info_t

### DIFF
--- a/Airbrake/notifier/ABNotice.h
+++ b/Airbrake/notifier/ABNotice.h
@@ -39,7 +39,7 @@ typedef struct ab_signal_info_t {
     void *user_data;
 	
 } ab_signal_info_t;
-ab_signal_info_t ab_signal_info;
+extern ab_signal_info_t ab_signal_info;
 
 // notice payload keys
 extern NSString * const ABNotifierOperatingSystemVersionKey;

--- a/Airbrake/notifier/ABNotice.m
+++ b/Airbrake/notifier/ABNotice.m
@@ -29,6 +29,7 @@
 
 #import "ABNotifier.h"
 
+ab_signal_info_t ab_signal_info;
 
 // library constants
 NSString * const ABNotifierOperatingSystemVersionKey    = @"Operating System";


### PR DESCRIPTION
In order to fix a bug that prevents the project from compiling, this
commit adds extern to the ab_signal_info variable and also adds the
implementation into ABNotice.m.