### PR TITLE
UIAlertController presentation crashes

### DIFF
--- a/Airbrake/notifier/ABNotifier.m
+++ b/Airbrake/notifier/ABNotifier.m
@@ -673,7 +673,7 @@ void ABNotifierReachabilityDidChange(SCNetworkReachabilityRef target, SCNetworkR
     if ([UIAlertController class]) {
         UIAlertController *alert= [UIAlertController alertControllerWithTitle:title
                                                                       message:body
-                                                               preferredStyle:UIAlertControllerStyleActionSheet];
+                                                               preferredStyle:UIAlertControllerStyleAlert];
         UIAlertAction* alwaysSend = [UIAlertAction actionWithTitle:ABLocalizedString(@"ALWAYS_SEND")
                                                              style:UIAlertActionStyleDefault
                                                            handler:^(UIAlertAction * action){


### PR DESCRIPTION
On >iOS8 devices, the implementation of `+ (void)showNoticeAlertForNoticesWithPaths:(NSArray *)paths;` tries to present a `UIAlertController` with style of `UIAlertControllerStyleActionSheet` without setting a sourceView and sourceRect, and causes the app to crash.

There are two possible ways to fix the issue - one is by setting a `sourceView` and `sourceRect` for the `UIAlertController` via its `popoverPresentationController` property, and the other is by changing the style of the alert to `UIAlertControllerStyleAlert`, which would be my recommended approach to maintain a similar user experience across all iOS versions.
