### PR TITLE
Use bundleForClass: instead of mainBundle for framework compatibility

### DIFF
--- a/Airbrake/notifier/ABNotifierFunctions.m
+++ b/Airbrake/notifier/ABNotifierFunctions.m
@@ -351,7 +351,7 @@ NSString *ABLocalizedString(NSString* key) {
     static NSBundle *bundle = nil;
     static dispatch_once_t token;
     dispatch_once(&token, ^{
-        NSString *path = [[NSBundle mainBundle] pathForResource:@"ABNotifier" ofType:@"bundle"];
+        NSString *path = [[NSBundle bundleForClass:[ABNotifier class]] pathForResource:@"ABNotifier" ofType:@"bundle"];
         bundle = [[NSBundle alloc] initWithPath:path];
     });
     return [bundle localizedStringForKey:key value:key table:nil];


### PR DESCRIPTION
When building Airbrake as a framework, `[[NSBundle mainBundle] pathForResource:@"ABNotifier" ofType:@"bundle"]` in `ABLocalizedString` will return `nil`. To support frameworks *and* static libraries, this should be changed to `[[NSBundle bundleForClass:[ABNotifier class]] pathForResource:@"ABNotifier" ofType:@"bundle"]` or something similar.

In the current implementation, there is an assertion failure and crash when building notice alerts.

There is quite a bit more information in the [Pod Authors Guide to CocoaPods Frameworks](http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/) from the CocoaPods folks that may be helpful.