### PR TITLE
Use https by default

### DIFF
--- a/Airbrake/notifier/ABNotifier.m
+++ b/Airbrake/notifier/ABNotifier.m
@@ -37,7 +37,7 @@ static NSString * __ABProjectID = nil;
 //__hostName will be used to format the URL to post the crash report.
 //By default the hostName is airbrake.io and url is https://api.airbrake.io/api/v3/projects/%d/...
 static NSString * __hostName = nil;
-static BOOL __useSSL = NO;
+static BOOL __useSSL = YES;
 static BOOL __displayPrompt = YES;
 static NSString *__userName = @"Anonymous";
 static NSString *__envName = nil;

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ Running the notifier in Swift as framework
      ABNotifier.startNotifierWithAPIKey(
        YOUR_API_KEY,
        projectID: Your_Product_ID,
-       environmentName: ABNotifierAutomaticEnvironment,
-       useSSL: true
+       environmentName: ABNotifierAutomaticEnvironment
      );
      ```
 
@@ -180,7 +179,6 @@ Next, call the start notifier method at the very beginning of your
 [ABNotifier startNotifierWithAPIKey:@"YOUR_API_KEY"
                           projectID:@"Your_Product_ID"
                     environmentName:ABNotifierAutomaticEnvironment
-                             useSSL:YES // only if your account supports it
                            delegate:self];
 ```
 


### PR DESCRIPTION
Be consistent with API documentation and use https by default.