### PR TITLE
Loads CrashReporter framework within ABCrashReport.m

### DIFF
--- a/Airbrake/notifier/ABCrashReport.h
+++ b/Airbrake/notifier/ABCrashReport.h
@@ -7,7 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <CrashReporter/CrashReporter.h>
+@class PLCrashReporter;
+@class PLCrashReport;
 
 @interface ABCrashReport : NSObject
 @property (nonatomic, strong) PLCrashReporter *plCrashReporter;

--- a/Airbrake/notifier/ABCrashReport.m
+++ b/Airbrake/notifier/ABCrashReport.m
@@ -6,6 +6,7 @@
 //
 //
 
+#import <CrashReporter/CrashReporter.h>
 #import "ABCrashReport.h"
 #import "ABNotifierFunctions.h"
 #import "ABNotice.h"


### PR DESCRIPTION
Uses @class in ABCrashReport.h to declare PLCrashReporter and PLCrashReport
without having to import the CrashReporter framework in the header file.
This resolves an issue in which client apps failed to import Airbrake_iOS
due to the CrashReporter framework being private.

See [Github issue #58](https://github.com/airbrake/airbrake-ios/issues/58)

Authors: Adam Berlin (aberlin@pivotal.io) and Alex Basson (abasson@pivotal.io)