### PR TITLE
Fix podspec for macOS

### DIFF
--- a/Airbrake-iOS.podspec
+++ b/Airbrake-iOS.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   
   s.ios.deployment_target = '6.0'
   
-  s.osx.deployment_target = '10.8'
+  s.osx.deployment_target = '10.9'
 
   s.source       = { :git => "https://github.com/airbrake/airbrake-ios.git", :tag => "4.2.8" }
 

--- a/Airbrake-iOS.podspec
+++ b/Airbrake-iOS.podspec
@@ -15,7 +15,9 @@ Pod::Spec.new do |s|
   
   s.author       = "Jocelyn Harrington"
   
-  s.platform     = :ios, "6.0"
+  s.ios.deployment_target = '9.0'
+  
+  s.osx.deployment_target = '10.8'
 
   s.source       = { :git => "https://github.com/airbrake/airbrake-ios.git", :tag => "4.2.8" }
 

--- a/Airbrake-iOS.podspec
+++ b/Airbrake-iOS.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   
   s.author       = "Jocelyn Harrington"
   
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '6.0'
   
   s.osx.deployment_target = '10.8'
 


### PR DESCRIPTION
Deployment targets are the correct way to specify multiple platforms as per the [documentation](https://guides.cocoapods.org/syntax/podspec.html#deployment_target).

Just picked 10.8 minimum for macOS out of the air, can change it if needed - at least this lets you install the pod for both mac and iOS projects without errors.